### PR TITLE
Fix grammar in main.tf comments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "webserver" {
 }
 
 /*
-# create a ec2 instance
+# create an EC2 instance
 resource "aws_instance" "beb1" {
   ami           = "ami-0742b4e673072066f"  # Amazon Linux 2 (us-east-1)
   instance_type = "t2.micro"
@@ -21,7 +21,7 @@ resource "aws_instance" "beb1" {
 }
 
 
-# create a ec2 instance
+# create an EC2 instance
 resource "aws_instance" "Alb1" {
   ami           = "ami-0742b4e673072066f"  # Amazon Linux 2 (us-east-1)
   instance_type = "t2.micro"


### PR DESCRIPTION
## Summary
- fix grammar in commented EC2 instance descriptions

## Testing
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b14af15cc832389fb4f3ae698f372